### PR TITLE
start serving from the plats dir, change in www/* => `cordova prepare`

### DIFF
--- a/lib/livereload.js
+++ b/lib/livereload.js
@@ -28,16 +28,20 @@ var proxyMiddleware;
 
 var projectRoot,
     browserSync,
-    platformWWWDir; 
+    platformWWWDir;
 
 module.exports = LiveReload;
 
-// projectRoot: root folder of the project
-// platformWWW: www directory of the platform
-// opts: options.
-//    -openBrowser: should a browser window be launched after browserSync is initialized ?
+/**
+ * @constructor
+ * @param {string} projectRoot - root folder of the project
+ * @param {string} platformWWW - www directory of the platform
+ * @param {Object} opts - Options to initialize LiveReload with
+ * @param {Boolean} opts.openBrowser - should a browser window be launched after browserSync is initialized ? 
+ * @param {Object} context - Cordova's context object that gets passed to plugins
+ */
 function LiveReload(projectRoot, platformWWW, opts, context) {
-    
+
     if (!opts) {
         opts = {
             openBrowser: false
@@ -54,9 +58,9 @@ function LiveReload(projectRoot, platformWWW, opts, context) {
     // ToDO: provide gulp replace scripts to change urls
     // ToDO: Document livereload.json file to enable proxying of urls to get around CORS. livereload config file
     this.projectRoot = projectRoot;
-    this.livereloadConfigFile = path.join(this.projectRoot, 'livereload.json'); 
+    this.livereloadConfigFile = path.join(this.projectRoot, 'livereload.json');
     this.www_dir = path.join(this.projectRoot, 'www');
-    platformWWWDir = platformWWW; 
+    platformWWWDir = platformWWW;
     this.StartServer = StartServer;
 };
 
@@ -66,66 +70,66 @@ function StartServer() {
     var self = this;
     var deferred = Q.defer();
 
-    
+
     return Q().then(function() {
-	// ToDO: Rework this piece of code to remove deps installation : no longer needed as we do it right after plugin addition
-	// Require these modules after we're sure they've been installed
-	UAParser = require('ua-parser-js');
-	proxyMiddleware = require('proxy-middleware');
-	browserSync = require('browser-sync').create();
-	
-	// Process proxies
-	var middlewares = []; 
-	var proxy_middlewares = process_proxy_middlewares(this.livereloadConfigFile);
-	middlewares = proxy_middlewares.concat(middlewares); 
+        // ToDO: Rework this piece of code to remove deps installation : no longer needed as we do it right after plugin addition
+        // Require these modules after we're sure they've been installed
+        UAParser = require('ua-parser-js');
+        proxyMiddleware = require('proxy-middleware');
+        browserSync = require('browser-sync').create();
 
-	browserSync.watch(path.join(self.www_dir, '**/*.*'), {}, function(event, files) {
+        // Process proxies
+        var middlewares = [];
+        var proxy_middlewares = process_proxy_middlewares(this.livereloadConfigFile);
+        middlewares = proxy_middlewares.concat(middlewares);
 
-	    if (event !== 'change') {
-		return;
+        browserSync.watch(path.join(self.www_dir, '**/*.*'), {}, function(event, files) {
+
+            if (event !== 'change') {
+                return;
             }
 
             // run prepare before reloading.
-	    Q().then(function() {
-		self.context.cordova.prepare();
-	    }).then(function() {
-		browserSync.reload(files);
-	    });
-	});
+            Q().then(function() {
+                self.context.cordova.prepare();
+            }).then(function() {
+                browserSync.reload(files);
+            });
+        });
 
-	// Initialize the browser-sync instance
-	browserSync.init({
+        // Initialize the browser-sync instance
+        browserSync.init({
             server: {
-		baseDir: self.projectRoot,
-		directory: true,
-		middleware: middlewares
-	    }, 
-	    files: path.join(self.www_dir, '**/*.*'),
+                baseDir: self.projectRoot,
+                directory: true,
+                middleware: middlewares
+            },
+            files: path.join(self.www_dir, '**/*.*'),
             open: (self.opts.openBrowser || false),
-	    snippetOptions: {
-		rule: {
+            snippetOptions: {
+                rule: {
                     match: /<\/body>/i,
                     fn: function(snippet, match) {
-			return monkeyPatch() + snippet + match;
+                        return monkeyPatch() + snippet + match;
                     }
-		}
+                }
             }
-	}, function(err, bs) {
+        }, function(err, bs) {
 
-	    // Once BrowserSync is ready, resolve the promise
+            // Once BrowserSync is ready, resolve the promise
 
-	    if(err) {
-		deferred.reject(err);
-	    }
-            var server_url = bs.options.getIn(['urls', 'external']); 
-            deferred.resolve(server_url); 
-	});
+            if (err) {
+                deferred.reject(err);
+            }
+            var server_url = bs.options.getIn(['urls', 'external']);
+            deferred.resolve(server_url);
+        });
 
-	// Expose this so that devs can use it in their workflows (gulp, grunt, etc...)
-	self.BrowserSyncInstance = browserSync;
+        // Expose this so that devs can use it in their workflows (gulp, grunt, etc...)
+        self.BrowserSyncInstance = browserSync;
 
-    }).then(function(){
-	return deferred.promise;
+    }).then(function() {
+        return deferred.promise;
     });
 }
 
@@ -133,29 +137,29 @@ function StartServer() {
 // ToDO: bug with 2 routes: /demoserv & /demoserv2
 function process_proxy_middlewares(livereloadConfigFile) {
     var middlewares = [];
-    if(!fs.existsSync(livereloadConfigFile)){
-	return middlewares;
+    if (!fs.existsSync(livereloadConfigFile)) {
+        return middlewares;
     }
 
     var data;
 
     try {
-	data = JSON.parse(fs.readFileSync(livereloadConfigFile, 'utf-8'));
-    } catch(e) {
-	throw new Error('Error while parsing the file ' + livereloadConfigFile + '. Check its syntax.');
+        data = JSON.parse(fs.readFileSync(livereloadConfigFile, 'utf-8'));
+    } catch (e) {
+        throw new Error('Error while parsing the file ' + livereloadConfigFile + '. Check its syntax.');
     }
 
-    if(!data.hasOwnProperty('proxies') || !data.proxies){
-	return middlewares;
+    if (!data.hasOwnProperty('proxies') || !data.proxies) {
+        return middlewares;
     }
 
     // ToDO: test with https, http, wrong link, dead link
-    data.proxies.forEach(function(proxy){
-	var proxyOptions = url.parse(proxy.endpoint); 
-	proxyOptions.route = proxy.route;
-	middlewares.push(proxyMiddleware(proxyOptions));
+    data.proxies.forEach(function(proxy) {
+        var proxyOptions = url.parse(proxy.endpoint);
+        proxyOptions.route = proxy.route;
+        middlewares.push(proxyMiddleware(proxyOptions));
     });
-    
+
     return middlewares;
 }
 

--- a/lib/livereload.js
+++ b/lib/livereload.js
@@ -36,7 +36,7 @@ module.exports = LiveReload;
 // platformWWW: www directory of the platform
 // opts: options.
 //    -openBrowser: should a browser window be launched after browserSync is initialized ?
-function LiveReload(projectRoot, platformWWW, opts) {
+function LiveReload(projectRoot, platformWWW, opts, context) {
     
     if (!opts) {
         opts = {
@@ -44,18 +44,19 @@ function LiveReload(projectRoot, platformWWW, opts) {
         };
     }
 
+    this.context = context;
+
     // Set default options if necessary
     this.opts = opts;
     this.opts.openBrowser = opts.openBrowser || false;
 
-    // ToDO: Fix CSP on the app that gets loaded, so that things work : snippetOptions
     // ToDO: provide good documentation on how to resolve CORS issue in a pre-existing project.,
     // ToDO: provide gulp replace scripts to change urls
     // ToDO: Document livereload.json file to enable proxying of urls to get around CORS. livereload config file
     this.projectRoot = projectRoot;
     this.livereloadConfigFile = path.join(this.projectRoot, 'livereload.json'); 
     this.www_dir = path.join(this.projectRoot, 'www');
-    platformWWWDir = platformWWW; // ToDO: better names for www dirs ?
+    platformWWWDir = platformWWW; 
     this.StartServer = StartServer;
 };
 
@@ -74,29 +75,49 @@ function StartServer() {
 	browserSync = require('browser-sync').create();
 	
 	// Process proxies
-	var middlewares = [cordova_middleware];
+	var middlewares = []; 
 	var proxy_middlewares = process_proxy_middlewares(this.livereloadConfigFile);
 	middlewares = proxy_middlewares.concat(middlewares); 
 
+	browserSync.watch(path.join(self.www_dir, '**/*.*'), {}, function(event, files) {
+
+	    if (event !== 'change') {
+		return;
+            }
+
+            // run prepare before reloading.
+	    Q().then(function() {
+		self.context.cordova.prepare();
+	    }).then(function() {
+		browserSync.reload(files);
+	    });
+	});
+
 	// Initialize the browser-sync instance
 	browserSync.init({
-
-	    //ToDO: mention this in doc: that all files within all folders are being watched
-            files: [path.join(self.www_dir, '**/*.css'), path.join(self.www_dir, '**/*.html'), path.join(self.www_dir, '**/*.js')], 
-            server: [self.www_dir], 
-
-            /**
-             * Redirect requests for the following files/folders to the appropriate locations:
-             *  - cordova.js
-             *  - cordova_plugins.js
-             *  - plugins/*
-             */
-            middleware: middlewares, 
-            open: (self.opts.openBrowser || false)
+            server: {
+		baseDir: self.projectRoot,
+		directory: true,
+		middleware: middlewares
+	    }, 
+	    files: path.join(self.www_dir, '**/*.*'),
+            open: (self.opts.openBrowser || false),
+	    snippetOptions: {
+		rule: {
+                    match: /<\/body>/i,
+                    fn: function(snippet, match) {
+			return monkeyPatch() + snippet + match;
+                    }
+		}
+            }
 	}, function(err, bs) {
-            var server_url = bs.options.getIn(['urls', 'external']); 
-	    
+
 	    // Once BrowserSync is ready, resolve the promise
+
+	    if(err) {
+		deferred.reject(err);
+	    }
+            var server_url = bs.options.getIn(['urls', 'external']); 
             deferred.resolve(server_url); 
 	});
 
@@ -138,30 +159,24 @@ function process_proxy_middlewares(livereloadConfigFile) {
     return middlewares;
 }
 
-function cordova_middleware(req, res, next) {
-    var parsed = require('url').parse(req.url);
-    var reg1 = new RegExp('cordova.js');
-    var reg2 = new RegExp('cordova_plugins.js');
-    var reg3 = new RegExp('plugins/*');
-
-    // If the request looks like any of the following, render the requested file from the appropriate platform folder
-    if (reg1.test(parsed.pathname) || reg2.test(parsed.pathname) || reg3.test(parsed.pathname)) {
-        var parser = new UAParser();
-        parser.setUA(req.headers['user-agent']);
-
-        var platform = parser.getResult().os.name;
-
-        // ToDO: Test: what if the platform requested is not installed ?
-        // ToDO: Test: what if the platform requested has already been deleted from the filesystem ?
-        // ToDO: Test: what if the platform requested : search for other test cases
-        // ToDO: Test: Multiple platforms. `cordova run android ios --device --livereload`
-
-        var platformDir = platformWWWDir; //'/home/omefire/Projects/Force57/Uber-Customer/platforms/android/assets/www';  
-        var fileToRead = path.join(platformDir, req.url);
-
-        res.setHeader('Content-Type', 'text/javascript');
-        var fileContent = require('fs').readFileSync(fileToRead).toString();
-        res.end(fileContent);
-    }
-    next();
+/**
+ * Private function that adds the code snippet to deal with reloading
+ * files when they are served from platform folders
+ */
+function monkeyPatch() {
+    var script = function() {
+        window.__karma__ = true;
+        (function patch() {
+            if (typeof window.__bs === 'undefined') {
+                window.setTimeout(patch, 500);
+            } else {
+                var oldCanSync = window.__bs.prototype.canSync;
+                window.__bs.prototype.canSync = function(data, optPath) {
+                    data.url = window.location.pathname.substr(0, window.location.pathname.indexOf('/www')) + data.url.substr(data.url.indexOf('/www'));
+                    return oldCanSync.apply(this, [data, optPath]);
+                };
+            }
+        }());
+    };
+    return '<script>(' + script.toString() + '());</script>';
 }

--- a/lib/livereload.js
+++ b/lib/livereload.js
@@ -166,6 +166,8 @@ function process_proxy_middlewares(livereloadConfigFile) {
 /**
  * Private function that adds the code snippet to deal with reloading
  * files when they are served from platform folders
+ * This is necessary to allow clicks & scrolls (one of BrowserSync's functionalities) to function well across
+ *    different platforms (e.g: IOS and Android)
  */
 function monkeyPatch() {
     var script = function() {

--- a/lib/runHook.js
+++ b/lib/runHook.js
@@ -4,6 +4,7 @@ var events = require('./events');
 var path = require('path');
 var fs = require('fs');
 var CSPRemover = require('./CSPRemover');
+var url = require('url');
 
 // ToDO: Test: run 'cordova run --livereload --device' multiple times in a series
 // ToDO: Test: run 'cordova run --device' after '--livereload' and vice-versa
@@ -16,7 +17,7 @@ module.exports = function(context) {
     var et = context.requireCordovaModule('elementtree');
 
     // Allow livereload to be started by running: `cordova run android --livereload` or by running `cordova run android -- --livereload`
-    if (!options.livereload && (options.options.indexOf('--livereload') === -1) ) {
+    if (!options.livereload && (options.options.indexOf('--livereload') === -1)) {
         return Q();
     }
 
@@ -28,58 +29,61 @@ module.exports = function(context) {
     // ToDO: Integration with gulp + docs + examples
 
     var WWW_FOLDER = {
-	android: 'platforms/android/assets/www',
-	ios: 'platforms/ios/www'
+        android: 'platforms/android/assets/www',
+        ios: 'platforms/ios/www'
     };
-    
+
     var CONFIG_LOCATION = {
-	android: 'platforms/android/res/xml',
-	ios: 'platforms/ios/HelloCordova' 
+        android: 'platforms/android/res/xml',
+        ios: 'platforms/ios/HelloCordova'
     };
-    
+
     function parseXml(filename) {
-	return new et.ElementTree(et.XML(fs.readFileSync(filename, "utf-8").replace(/^\uFEFF/, "")));
+        return new et.ElementTree(et.XML(fs.readFileSync(filename, "utf-8").replace(/^\uFEFF/, "")));
     }
-    
+
     function changeConfigXml(hostedPage, configXML) {
-	var filename = configXML;
-	configXml = parseXml(filename);
-	var contentTag = configXml.find('content[@src]');
-	if (contentTag) {
+        var filename = configXML;
+        configXml = parseXml(filename);
+        var contentTag = configXml.find('content[@src]');
+        if (contentTag) {
             contentTag.attrib.src = hostedPage;
-	}
-	// Also add allow nav in case of 
-	var allowNavTag = et.SubElement(configXml.find('.'), 'allow-navigation');
-	allowNavTag.set('href', '*');
-	fs.writeFileSync(filename, configXml.write({
+        }
+        // Also add allow nav in case of 
+        var allowNavTag = et.SubElement(configXml.find('.'), 'allow-navigation');
+        allowNavTag.set('href', '*');
+        fs.writeFileSync(filename, configXml.write({
             indent: 4
-	}), "utf-8");
-	return filename;
+        }), "utf-8");
+        return filename;
     }
-    
+
     // When doing livereload, at least one platform has to successfully launch, otherwise we just abort ...
     var anyPlatformSucceeded = false;
 
     return Q()
         .then(function() {
 
-	    // Start LiveReload on all specified platforms serially, so that we don't collide over free ports
+            // Start LiveReload on all specified platforms serially, so that we don't collide over free ports
             // ... Also, if any platform fails, print a warning and carry on with the other ones.
             return promiseUtils.Q_chainmap_graceful(options.platforms, function(platform) {
 
                 var platform_www = path.join(projectRoot, WWW_FOLDER[platform]);
-		var configXml = path.join(projectRoot, CONFIG_LOCATION[platform], 'config.xml');
+                var configXml = path.join(projectRoot, CONFIG_LOCATION[platform], 'config.xml');
 
                 var LiveReload = require('./livereload');
-                return new LiveReload(projectRoot, platform_www, options).StartServer().then(function(server_url) {
-		    changeConfigXml(server_url, configXml);		    
-                    anyPlatformSucceeded = true;
+                return new LiveReload(projectRoot, platform_www, options, context).StartServer().then(function(server_url) {
+                    var platformIndexUrl = url.resolve(server_url, path.join(WWW_FOLDER[platform], 'index.html'));
+                    changeConfigXml(platformIndexUrl, configXml);
                     return Q();
                 }).then(function() {
-		    // Update CSP to allow calls to BrowserSync HTTP server
-		    var cspRemover = new CSPRemover(path.join(projectRoot, 'www', 'index.html')); 
-		    return cspRemover.Remove();		    
-		});
+                    // Remove CSP to allow calls to BrowserSync HTTP server
+		    var platformIndexLocal = path.join(platform_www, 'index.html');
+                    var cspRemover = new CSPRemover(platformIndexLocal);
+                    return cspRemover.Remove();
+                }).then(function() {
+                    anyPlatformSucceeded = true;
+                });
             }, function(err) {
                 events.emit('warn', err);
             });
@@ -87,13 +91,12 @@ module.exports = function(context) {
         .then(function() {
             // When doing livereload, at least one platform has to successfully launch, otherwise we just abort ...
             if (!anyPlatformSucceeded) {
-	        var msg = 'cordova-plugin-livereload: Livereload failed on all platforms, thus the "run" process is being aborted ... ';
-	        events.emit('warn', msg); 
+                var msg = 'cordova-plugin-livereload: Livereload failed on all platforms, thus the "run" process is being aborted ... ';
+                events.emit('warn', msg);
                 return Q.reject(msg);
             }
             return Q();
         }, function(err) {
-	    events.emit('warn', err);
-	});
+            events.emit('warn', err);
+        });
 };
-


### PR DESCRIPTION
- Start serving from the platforms directory.
      Advantages:
           \* Better support for custom workflows: .sass file changed -> gulp compile -> copy results to platform dir -> BrowserSync(LiveReload) picks up changes from platform dir
           \* Support for changes to cordova merges directory
- Whenever a change happens in the www/\* dir, run `cordova prepare`
