### PR TITLE
1- Show meaningful msg to user after livereload start, 2- Stop processing on livereload setup error

### DIFF
--- a/lib/dependenciesInstall.js
+++ b/lib/dependenciesInstall.js
@@ -1,5 +1,6 @@
 var fs = require('fs');
 var path = require('path');
+var logger = require('./utils/logger');
 
 // This function gets called after every plugin addition, as specified in plugin.xml
 module.exports = function(context) {
@@ -56,15 +57,15 @@ module.exports = function(context) {
             loaded: false
         }, function(err) {
             if (err) {
-                console.log('cordova-plugin-livereload: An error occurred while loading npm');
-                reject('cordova-plugin-livereload: npm load failed.');
+                logger.show('An error occurred while loading npm');
+                reject(err);
                 return;
             }
             npm.commands.install(packageJSONDir, packagesToInstall, function(er, data) {
                 // log the error or data
                 if (err) {
-                    console.log('cordova-plugin-livereload: dependencies install failed.');
-                    reject('cordova-plugin-livereload: dependencies install failed.');
+                    logger.show('dependencies install failed.');
+                    reject(err);
                     return;
                 }
                 resolve();

--- a/lib/livereload.js
+++ b/lib/livereload.js
@@ -119,8 +119,9 @@ function StartServer() {
             // In case there is no external url
             // e.g: When the machine is not connected to any network
             if (!server_url) {
-                logger.show('No external url available.\n ' + err);
-                deferred.reject(err);
+		// Usually, this err msg ends up being null in this case.
+		var error = new Error('No External URLs available. Make sure your computer is connected to a network.' + (err ? err.msg : ''));
+                deferred.reject(error);
             }
 
             deferred.resolve(server_url);

--- a/lib/livereload.js
+++ b/lib/livereload.js
@@ -21,7 +21,7 @@ var path = require('path');
 var Q = require('q');
 var fs = require('fs');
 var url = require('url');
-var events = require('./utils/events');
+var logger = require('./utils/logger');
 
 var projectRoot,
     browserSync,
@@ -115,8 +115,12 @@ function StartServer() {
             }
 
             var server_url = bs.options.getIn(['urls', 'external']);
-            if (!server_url) { // test for null. does this exit immediately or does it execute deferred.resolve as well ?
-                deferred.reject('No external url available');
+
+            // In case there is no external url
+            // e.g: When the machine is not connected to any network
+            if (!server_url) {
+                logger.show('No external url available.\n ' + err);
+                deferred.reject(err);
             }
 
             deferred.resolve(server_url);
@@ -131,10 +135,7 @@ function StartServer() {
 }
 
 function StopServer() {
-    if (browserSync) {
-        browserSync.exit();
-    }
-    return Q();
+    browserSync.exit();
 }
 
 

--- a/lib/livereload.js
+++ b/lib/livereload.js
@@ -55,6 +55,7 @@ function LiveReload(projectRoot, platformWWWs, opts, prepareFn) {
     this.www_dir = path.join(this.projectRoot, 'www');
     platformWWWDirs = platformWWWs;
     this.StartServer = StartServer;
+    this.StopServer = StopServer;
 };
 
 
@@ -112,7 +113,12 @@ function StartServer() {
             if (err) {
                 deferred.reject(err);
             }
+
             var server_url = bs.options.getIn(['urls', 'external']);
+            if (!server_url) { // test for null. does this exit immediately or does it execute deferred.resolve as well ?
+                deferred.reject('No external url available');
+            }
+
             deferred.resolve(server_url);
         });
 
@@ -122,6 +128,13 @@ function StartServer() {
     }).then(function() {
         return deferred.promise;
     });
+}
+
+function StopServer() {
+    if (browserSync) {
+        browserSync.exit();
+    }
+    return Q();
 }
 
 

--- a/lib/postPrepareHook.js
+++ b/lib/postPrepareHook.js
@@ -37,9 +37,10 @@ module.exports = function(context) {
         return path.join(projectRoot, multiPlatforms.getPlatformWWWFolder(plat));
     });
 
+    var LiveReload = require('./livereload'),
+        lr = new LiveReload(projectRoot, platform_wwws, options, context.cordova.raw.prepare);
 
-    var LiveReload = require('./livereload');
-    return new LiveReload(projectRoot, platform_wwws, options, context.cordova.raw.prepare).StartServer().then(function(server_url) {
+    return lr.StartServer().then(function(server_url) {
         return promiseUtils.Q_chainmap(options.platforms, function(plat) {
             var configXml = path.join(projectRoot, multiPlatforms.getConfigFolder(plat), 'config.xml');
             var platformIndexUrl = url.resolve(server_url, path.join(multiPlatforms.getPlatformWWWFolder(plat), 'index.html'));
@@ -52,8 +53,11 @@ module.exports = function(context) {
             return cspRemover.Remove();
         });
     }).fail(function(err) {
-        var msg = pluginName + ': An error occurred' + JSON.stringify(err);
-        events.emit('warn', err);
-        return Q.reject(msg);
+        var msg = pluginName + ' - An error occurred: ' + err;
+        //events.emit('warn', msg);
+        console.log(msg);
+
+	// Stop the current process
+        lr.StopServer();
     });
 };

--- a/lib/postPrepareHook.js
+++ b/lib/postPrepareHook.js
@@ -1,12 +1,12 @@
 var Q = require('q');
 var promiseUtils = require('./utils/promise-util');
-var events = require('./utils/events');
 var path = require('path');
 var fs = require('fs');
 var CSPRemover = require('./utils/CSPRemover');
 var url = require('url');
 var multiPlatforms = require('./utils/platforms');
 var configParser = require('./utils/configParser');
+var logger = require('./utils/logger');
 
 module.exports = function(context) {
 
@@ -23,14 +23,17 @@ module.exports = function(context) {
     // If a platform is not supported by the plugin, display an error message and don't process it any further
     options.platforms.forEach(function(plat, index, platforms) {
         if (!multiPlatforms.isPlatformSupported(plat)) {
-            events.emit('warn', pluginName + ':  The "' + plat + '" platform is not supported.');
+            var msg = 'The "' + plat + '" platform is not supported.';
+            logger.show(msg);
             platforms.splice(index, 1);
         }
     });
 
     // If none of the supplied platforms are supported, stop and return an error
-    if (options.platforms === undefined || options.platforms.length == 0) {
-        return Q.reject(pluginName + ': None of the platforms supplied are currently supported.');
+    if (options.platforms === undefined || options.platforms.length === 0) {
+        var msg = 'None of the platforms supplied are currently supported for LiveReload.';
+        logger.show(msg);
+        return Q.reject(msg);
     }
 
     var platform_wwws = options.platforms.map(function(plat) {
@@ -54,10 +57,9 @@ module.exports = function(context) {
         });
     }).fail(function(err) {
         var msg = pluginName + ' - An error occurred: ' + err;
-        //events.emit('warn', msg);
-        console.log(msg);
+        logger.show(msg);
 
-	// Stop the current process
+        // Stop the current process
         lr.StopServer();
     });
 };

--- a/lib/postRunHook.js
+++ b/lib/postRunHook.js
@@ -1,0 +1,16 @@
+var Q = require('q');
+var events = require('./utils/events');
+var os = require('os');
+
+module.exports = function(context) {
+
+    var pluginName = require('../package.json').name;
+
+    // Let the user know how he can kill the LiveReload/BrowserSync server
+    var msg = os.EOL;
+    msg += pluginName + ' - ' + 'LiveReload server running: ' + os.EOL + 'To kill it, please use: "CTRL+C" ' + os.EOL;
+
+    console.log(msg);
+
+    return Q();
+};

--- a/lib/postRunHook.js
+++ b/lib/postRunHook.js
@@ -1,16 +1,21 @@
 var Q = require('q');
 var events = require('./utils/events');
 var os = require('os');
+var logger = require('./utils/logger');
 
 module.exports = function(context) {
 
-    var pluginName = require('../package.json').name;
+    var options = context.opts;
 
-    // Let the user know how he can kill the LiveReload/BrowserSync server
-    var msg = os.EOL;
-    msg += pluginName + ' - ' + 'LiveReload server running: ' + os.EOL + 'To kill it, please use: "CTRL+C" ' + os.EOL;
+    // Check whether the livereload flag is present
+    if (!options.livereload && (options.options.indexOf('--livereload') === -1)) {
+        return Q();
+    }
 
-    console.log(msg);
-
+    // If the livereload flag is present, and we are running this function, 
+    // it means the server was successfully started.
+    // Therefores, let the user know how he can kill the LiveReload/BrowserSync server
+    var msg = 'LiveReload server running: ' + os.EOL + 'To kill it, please use: "CTRL+C" ' + os.EOL;
+    logger.show(msg);
     return Q();
 };

--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -1,0 +1,7 @@
+
+var os = require('os');
+
+module.exports.show = function(msg) {
+    var pluginName = require('../../package.json').name;
+    console.log(os.EOL + pluginName + ' : ' + os.EOL + msg);
+};

--- a/plugin.xml
+++ b/plugin.xml
@@ -12,5 +12,6 @@
     <repo>...</repo>
 
     <hook type="after_plugin_add" src="lib/dependenciesInstall.js" />
-    <hook type="after_prepare" src="lib/runHook.js" />
+    <hook type="after_prepare" src="lib/postPrepareHook.js" />
+    <hook type="after_run" src="lib/postRunHook.js" />
 </plugin>


### PR DESCRIPTION
This PR intends to show meaningful msg to user after livereload has started.
One of the approaches could be by passing a msg to be displayed after the run command has completed from post_prepare_hook to post_run_hook.

This PR shall not be merged in the current form as it's work in progress. It's meant as a way of communicating design and brainstorm solutions.

What is the best way to provide a meaningful message at the end of the `cordova run android -- --livereload` command ? 
(e.g of msg: "LiveReload server running at http://.... . To Stop, please use 'ctrl+c'").
