### PR TITLE
Prevent non livereload-compatible commands from starting LiveReload, 

### DIFF
--- a/lib/postPrepareHook.js
+++ b/lib/postPrepareHook.js
@@ -7,6 +7,7 @@ var url = require('url');
 var multiPlatforms = require('./utils/platforms');
 var configParser = require('./utils/configParser');
 var logger = require('./utils/logger');
+var helpers = require('./utils/helpers');
 
 module.exports = function(context) {
 
@@ -14,8 +15,9 @@ module.exports = function(context) {
     var options = context.opts;
     var projectRoot = context.opts.projectRoot;
 
-    // Allow livereload to be started by running: `cordova run android --livereload` or by running `cordova run android -- --livereload`
-    if (!options.livereload && (options.options.indexOf('--livereload') === -1)) {
+    // This check prevents commands that call the prepare process,
+    // such as: `cordova build android -- --livereload` from starting the LiveReload process
+    if (!helpers.IsCmdLiveReloadCompatible(context)) {
         return Q();
     }
 

--- a/lib/postRunHook.js
+++ b/lib/postRunHook.js
@@ -2,19 +2,18 @@ var Q = require('q');
 var events = require('./utils/events');
 var os = require('os');
 var logger = require('./utils/logger');
+var helpers = require('./utils/helpers');
 
 module.exports = function(context) {
 
-    var options = context.opts;
-
-    // Check whether the livereload flag is present
-    if (!options.livereload && (options.options.indexOf('--livereload') === -1)) {
+    // Check whether the command being run is livereload-compatible
+    if (!helpers.IsCmdLiveReloadCompatible(context)) {
         return Q();
     }
 
-    // If the livereload flag is present, and we are running this function, 
+    // If the command is livereload-compatible, and we are running this function, 
     // it means the server was successfully started.
-    // Therefores, let the user know how he can kill the LiveReload/BrowserSync server
+    // Therefore, let the user know how he can kill the LiveReload/BrowserSync server
     var msg = 'LiveReload server running: ' + os.EOL + 'To kill it, please use: "CTRL+C" ' + os.EOL;
     logger.show(msg);
     return Q();

--- a/lib/utils/helpers.js
+++ b/lib/utils/helpers.js
@@ -1,0 +1,36 @@
+/**
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+// Checks whether a command is compatible with livereload
+// Currently, Only the following commands are compatible with LiveReload :
+//     - `cordova run android -- --livereload` 
+//     - `cordova run android --livereload`
+//     - `cordova emulate android -- --livereload`
+//     - `cordova emulate android --livereload`
+module.exports.IsCmdLiveReloadCompatible = function(context) {
+
+    // Allow livereload to be started by running: `cordova run android --livereload` or by running `cordova run android -- --livereload`
+    if (!context.opts.livereload && (context.opts.options.indexOf('--livereload') === -1)) {
+        return false;
+    }
+
+    // Has the user issued a livereload compatible command ? e.g: run or emulate
+    var cordovaRunRegex = /(.*)(cordova)(\s+)(run|emulate)(.*)/i;
+    var isCordovaRunCmd = cordovaRunRegex.test(context.cmdLine);
+
+    return isCordovaRunCmd ? true : false;
+};

--- a/lib/utils/helpers.js
+++ b/lib/utils/helpers.js
@@ -1,26 +1,21 @@
 /**
-    Licensed to the Apache Software Foundation (ASF) under one
-    or more contributor license agreements.  See the NOTICE file
-    distributed with this work for additional information
-    regarding copyright ownership.  The ASF licenses this file
-    to you under the Apache License, Version 2.0 (the
-    "License"); you may not use this file except in compliance
-    with the License.  You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing,
-    software distributed under the License is distributed on an
-    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-    KIND, either express or implied.  See the License for the
-    specific language governing permissions and limitations
-    under the License.
-*/
+﻿ *******************************************************
+﻿ *                                                     *
+﻿ *   Copyright (C) Microsoft. All rights reserved.     *
+﻿ *                                                     *
+﻿ *******************************************************
+﻿ */
 
 // Checks whether a command is compatible with livereload
-// Currently, Only the following commands are compatible with LiveReload :
+// Currently, Only the following commands are compatible with LiveReload : `* (run|emulate) android -- --livereload`, `* (run|emulate) android --livereload`
+//   Examples:
 //     - `cordova run android -- --livereload` 
+//     - `phonegap run android -- --livereload`
 //     - `cordova run android --livereload`
 //     - `cordova emulate android -- --livereload`
 //     - `cordova emulate android --livereload`
+//     - `taco emulate android --livereload`
+//     - `phonegap emulate android --livereload`
 module.exports.IsCmdLiveReloadCompatible = function(context) {
 
     // Allow livereload to be started by running: `cordova run android --livereload` or by running `cordova run android -- --livereload`
@@ -29,7 +24,7 @@ module.exports.IsCmdLiveReloadCompatible = function(context) {
     }
 
     // Has the user issued a livereload compatible command ? e.g: run or emulate
-    var cordovaRunRegex = /(.*)(cordova)(\s+)(run|emulate)(.*)/i;
+    var cordovaRunRegex = /(.*)(run|emulate)(.*)/i;
     var isCordovaRunCmd = cordovaRunRegex.test(context.cmdLine);
 
     return isCordovaRunCmd ? true : false;


### PR DESCRIPTION
Certain cordova commands should not be allowed to start the LiveReload process, even though it calls prepare. (We kick the LiveReload process after listening to prepare command).
e.g: cordova build <platform> -- --livereload (LiveReload should not be kicked off by this command).
