### PR TITLE
Older cordova projects can have their config.xml located in www dir instead of projectRoot dir

### DIFF
--- a/lib/utils/helpers.js
+++ b/lib/utils/helpers.js
@@ -11,6 +11,7 @@ var path = require('path');
 var configParser = require('./configParser');
 var glob = require('glob');
 var multiPlatforms = require('./platforms');
+var fs = require('fs');
 
 // Checks whether a command is compatible with livereload
 // Currently, Only the following commands are compatible with LiveReload : `* (run|emulate) android -- --livereload`, `* (run|emulate) android --livereload`
@@ -36,9 +37,21 @@ module.exports.IsCmdLiveReloadCompatible = function(context) {
     return isCordovaRunCmd ? true : false;
 };
 
+// config.xml can be found in the projectRoot directory or within the projectRoot/www folder
+module.exports.GetConfigXMLFile = GetConfigXMLFile = function(projectRoot) {
+    var rootPath = path.join(projectRoot, 'config.xml');
+    var wwwPath = path.join(projectRoot, 'www', 'config.xml');
+    if (fs.existsSync(rootPath)) {
+	return rootPath;
+    } else if (fs.existsSync(wwwPath)) {
+	return wwwPath;
+    }
+    return rootPath;
+};
+
 // Retrieve the start page for a cordova project, given the project's root directory
 module.exports.GetStartPage = function(projectRoot) {
-    var configXML = path.join(projectRoot, 'config.xml');
+    var configXML = GetConfigXMLFile(projectRoot);
     var startPage = configParser.GetStartPage(configXML);
     return startPage;
 };


### PR DESCRIPTION
In older versions of cordova, the config.xml file can be found within the www directory instead of the project root.

This PR handles that case.
