### PR TITLE
Adding support for emulate

### DIFF
--- a/lib/postEmulateRunHook.js
+++ b/lib/postEmulateRunHook.js
@@ -1,10 +1,10 @@
 /**
-﻿ *******************************************************
-﻿ *                                                     *
-﻿ *   Copyright (C) Microsoft. All rights reserved.     *
-﻿ *                                                     *
-﻿ *******************************************************
-﻿ */
+ *******************************************************
+ *                                                     *
+ *   Copyright (C) Microsoft. All rights reserved.     *
+ *                                                     *
+ *******************************************************
+ */
 
 var Q = require('q');
 var events = require('./utils/events');
@@ -14,8 +14,8 @@ var helpers = require('./utils/helpers');
 
 module.exports = function(context) {
 
-    // Check whether the command being run is livereload-compatible
-    if (!helpers.IsCmdLiveReloadCompatible(context)) {
+    // Only continue is LiveReload is up and running
+    if (!helpers.isLiveReloadActive()) {
         return Q();
     }
 

--- a/lib/postEmulateRunHook.js
+++ b/lib/postEmulateRunHook.js
@@ -15,7 +15,7 @@ var helpers = require('./utils/helpers');
 module.exports = function(context) {
 
     // Only continue is LiveReload is up and running
-    if (!helpers.isLiveReloadActive()) {
+    if (!helpers.isLiveReloadActivated()) {
         return Q();
     }
 

--- a/lib/postPrepareHook.js
+++ b/lib/postPrepareHook.js
@@ -51,11 +51,11 @@ module.exports = function(context) {
 
     var startPage = helpers.GetStartPage(projectRoot),
         LiveReload = require('./livereload'),
-        livereloadOptions = helpers.ParseOptions();
+        livereloadOptions = helpers.parseOptions();
 
 
     // If user has entered whitespaces surrounding '--ignore', 
-    // ... we end up having helpers.ParseOptions() return 'ignore' with value true instead of a string,
+    // ... we end up having helpers.parseOptions() return 'ignore' with value true instead of a string,
     // ... which can't be used as a string. So, Let's check for those cases
     // e.g of error cases: 
     //      `cordova run android -- --livereload --ignore, // with no path to ignore

--- a/lib/postPrepareHook.js
+++ b/lib/postPrepareHook.js
@@ -22,9 +22,14 @@ module.exports = function(context) {
     var options = context.opts;
     var projectRoot = context.opts.projectRoot;
 
+    var livereloadOptions = helpers.ParseOptions(process.argv);
+
     // This check prevents commands that call the prepare process,
     // such as: `cordova build android -- --livereload` from starting the LiveReload process
-    if (!helpers.IsCmdLiveReloadCompatible(context)) {
+
+    // If 
+    var isCompatibleCmd = livereloadOptions.livereload && (livereloadOptions.run || livereloadOptions.emulate);
+    if (!isCompatibleCmd) { //(!helpers.IsCmdLiveReloadCompatible(context)) {
         return Q();
     }
 
@@ -50,8 +55,8 @@ module.exports = function(context) {
     });
 
     var startPage = helpers.GetStartPage(projectRoot),
-        LiveReload = require('./livereload'),
-        parsedOptions = helpers.ParseOptions(context.opts.options);
+        LiveReload = require('./livereload');
+    //parsedOptions = helpers.ParseOptions(context.opts.options);
 
 
     // If user has entered whitespaces surrounding '--ignore', 
@@ -62,9 +67,10 @@ module.exports = function(context) {
     //      `cordova run android -- --livereload --ignore= css, // with space after the '=' sign
     //      etc...
     // ToDO: ignore whitespaces surrounding the --ignore option or at least display a warning message to user
+    debugger;
     var ignoreOption = undefined;
-    if (typeof parsedOptions['ignore'] === 'string') { 
-        ignoreOption = path.join(projectRoot, 'www', parsedOptions['ignore']);
+    if (livereloadOptions.ignore) { //(typeof parsedOptions['ignore'] === 'string') {
+        ignoreOption = path.join(projectRoot, 'www', livereloadOptions.ignore); // parsedOptions['ignore']);
     }
 
     var lr = new LiveReload(projectRoot, platform_wwws, {

--- a/lib/postPrepareHook.js
+++ b/lib/postPrepareHook.js
@@ -22,14 +22,9 @@ module.exports = function(context) {
     var options = context.opts;
     var projectRoot = context.opts.projectRoot;
 
-    var livereloadOptions = helpers.ParseOptions(process.argv);
-
     // This check prevents commands that call the prepare process,
     // such as: `cordova build android -- --livereload` from starting the LiveReload process
-
-    // If 
-    var isCompatibleCmd = livereloadOptions.livereload && (livereloadOptions.run || livereloadOptions.emulate);
-    if (!isCompatibleCmd) { //(!helpers.IsCmdLiveReloadCompatible(context)) {
+    if (!helpers.IsCmdLiveReloadCompatible(context)) {
         return Q();
     }
 
@@ -55,8 +50,8 @@ module.exports = function(context) {
     });
 
     var startPage = helpers.GetStartPage(projectRoot),
-        LiveReload = require('./livereload');
-    //parsedOptions = helpers.ParseOptions(context.opts.options);
+        LiveReload = require('./livereload'),
+        livereloadOptions = helpers.ParseOptions();
 
 
     // If user has entered whitespaces surrounding '--ignore', 
@@ -67,10 +62,9 @@ module.exports = function(context) {
     //      `cordova run android -- --livereload --ignore= css, // with space after the '=' sign
     //      etc...
     // ToDO: ignore whitespaces surrounding the --ignore option or at least display a warning message to user
-    debugger;
     var ignoreOption = undefined;
-    if (livereloadOptions.ignore) { //(typeof parsedOptions['ignore'] === 'string') {
-        ignoreOption = path.join(projectRoot, 'www', livereloadOptions.ignore); // parsedOptions['ignore']);
+    if (livereloadOptions.ignore) {
+        ignoreOption = path.join(projectRoot, 'www', livereloadOptions.ignore);
     }
 
     var lr = new LiveReload(projectRoot, platform_wwws, {
@@ -101,6 +95,7 @@ module.exports = function(context) {
                 }).fail(function(err) {
                     var msg = ' - An error occurred: ' + err;
                     logger.show(msg);
+                    lr.stopServer();
                 });
             }
         }],
@@ -130,6 +125,9 @@ module.exports = function(context) {
             var cspRemover = new CSPRemover(platformIndexLocal);
             return cspRemover.Remove();
         });
+    }).then(function() {
+        // LiveReload is up and running
+        helpers.setLiveReloadToActive();
     }).fail(function(err) {
         var msg = pluginName + ' - An error occurred: ' + err;
         logger.show(msg);

--- a/lib/utils/helpers.js
+++ b/lib/utils/helpers.js
@@ -29,8 +29,8 @@ module.exports.IsCmdLiveReloadCompatible = function(context) {
     // There is a bug in cordova-lib upto at least version 5.3.x that prevents the `cordova emulate` command 
     // ... from passing context object of plugins from passing the -- --livereload flag correctly.
     // ... using `isLiveReloadActive` allows us to circumvent that issue.
-    var livereloadOptions = ParseOptions();
-    return livereloadOptions.livereload && ((livereloadOptions.run || livereloadOptions.emulate) && !isLiveReloadActive()); // Make sure we're not already in livereload mode
+    var livereloadOptions = parseOptions();
+    return livereloadOptions.livereload && ((livereloadOptions.run || livereloadOptions.emulate) && !isLiveReloadActivated()); // Make sure we're not already in livereload mode
 };
 
 // config.xml can be found in the projectRoot directory or within the projectRoot/www folder
@@ -64,7 +64,7 @@ module.exports.ChangeStartPage = function(projectRoot, plat, platformIndexUrl) {
 };
 
 // Parses LiveReload options off of process.argv
-module.exports.ParseOptions = ParseOptions = function() {
+module.exports.parseOptions = parseOptions = function() {
 
     var knownOpts = {
         'livereload': Boolean,
@@ -86,6 +86,6 @@ module.exports.setLiveReloadToActive = function() {
     GLOBAL.isLiveReloadActive = true;
 };
 
-module.exports.isLiveReloadActive = isLiveReloadActive = function() {
+module.exports.isLiveReloadActivated = isLiveReloadActivated = function() {
     return !!GLOBAL.isLiveReloadActive;
 };

--- a/lib/utils/helpers.js
+++ b/lib/utils/helpers.js
@@ -12,6 +12,7 @@ var configParser = require('./configParser');
 var glob = require('glob');
 var multiPlatforms = require('./platforms');
 var fs = require('fs');
+var nopt = require('nopt');
 
 // Checks whether a command is compatible with livereload
 // Currently, Only the following commands are compatible with LiveReload : `* (run|emulate) android -- --livereload`, `* (run|emulate) android --livereload`
@@ -23,18 +24,27 @@ var fs = require('fs');
 //     - `cordova emulate android --livereload`
 //     - `taco emulate android --livereload`
 //     - `phonegap emulate android --livereload`
-module.exports.IsCmdLiveReloadCompatible = function(context) {
+// Remove this !
+module.exports.IsCmdLiveReloadCompatible = function(context, livereloadOptions) {
+
+    // There is a bug in cordova-lib upto at least version 5.3.x that prevents 
+    // ... the context object of plugins from passing the -- --livereload flag correctly.
+    // ... directly inspecting the process.argv allows us to circumvent that issue.
+    var emulateWithLiveReload = ParseOptions(process.argv).livereload;
 
     // Allow livereload to be started by running: `cordova run android --livereload` or by running `cordova run android -- --livereload`
-    if (!context.opts.livereload && (context.opts.options.indexOf('--livereload') === -1)) {
+    var isLiveReload = (context.opts.options.indexOf('--livereload') === -1);
+    isLiveReload = isLiveReload || emulateWithLiveReload;
+    if (!context.opts.livereload && isLiveReload) {
         return false;
     }
 
     // Has the user issued a livereload compatible command ? e.g: run or emulate
-    var cordovaRunRegex = /(.*)(run|emulate)(.*)/i;
-    var isCordovaRunCmd = cordovaRunRegex.test(context.cmdLine);
+    var regex = /(.*)(run|emulate)(.*)/i;
 
-    return isCordovaRunCmd ? true : false;
+    var isCordovaRunOrEmulateCmd = regex.test(context.cmdLine);
+
+    return isCordovaRunOrEmulateCmd ? true : false;
 };
 
 // config.xml can be found in the projectRoot directory or within the projectRoot/www folder
@@ -42,9 +52,9 @@ module.exports.GetConfigXMLFile = GetConfigXMLFile = function(projectRoot) {
     var rootPath = path.join(projectRoot, 'config.xml');
     var wwwPath = path.join(projectRoot, 'www', 'config.xml');
     if (fs.existsSync(rootPath)) {
-	return rootPath;
+        return rootPath;
     } else if (fs.existsSync(wwwPath)) {
-	return wwwPath;
+        return wwwPath;
     }
     return rootPath;
 };
@@ -67,21 +77,29 @@ module.exports.ChangeStartPage = function(projectRoot, plat, platformIndexUrl) {
     });
 };
 
-module.exports.ParseOptions = function(opts) {
-    var result = {};
-    opts.forEach(function(opt) {
-        var parts = opt.split(/=/);
-        var option = parts[0];
-        var value = parts[1];
+// Parses LiveReload options off of process.argv
+module.exports.ParseOptions = ParseOptions = function(processArgv) {
 
-        // Remove dashes. e.g: --livereload => livereload
-        // Remove space surrounding options. e.g: --ignore= build/**/*.* => --ignore=build/**/*.*
-        var cleanedOption = option.replace(/^-+/, '');
-        if (!value) {
-            result[cleanedOption] = true;
-            return;
-        }
-        result[cleanedOption.replace(/\s+/, '')] = (value && value.replace(/\s+/, '')) || true;
-    });
-    return result;
+    var knownOpts = {
+        'livereload': Boolean,
+        'ignore': String
+    };
+
+    processArgv = processArgv || process.args;
+
+    debugger;
+
+    var parsedOptions = nopt(knownOpts, {}, processArgv, 2);
+
+    // All livereload options happen after the -- -- 
+    // What if we want to enable --livereload in the future ? (instead of -- --livereload) : `cordova run android --livereload`
+    // Test all cases !
+    var parsedLivereloadOptions = nopt(knownOpts, {}, parsedOptions.argv.remain, 2);
+
+    return {
+        run: parsedOptions.argv.original.indexOf('run') > -1,
+        emulate: parsedOptions.argv.original.indexOf('emulate') > -1,
+        livereload: parsedOptions.livereload || parsedLivereloadOptions.livereload,
+        ignore: parsedOptions.ignore || parsedLivereloadOptions.ignore
+    };
 };

--- a/lib/utils/helpers.js
+++ b/lib/utils/helpers.js
@@ -24,27 +24,13 @@ var nopt = require('nopt');
 //     - `cordova emulate android --livereload`
 //     - `taco emulate android --livereload`
 //     - `phonegap emulate android --livereload`
-// Remove this !
-module.exports.IsCmdLiveReloadCompatible = function(context, livereloadOptions) {
+module.exports.IsCmdLiveReloadCompatible = function(context) {
 
-    // There is a bug in cordova-lib upto at least version 5.3.x that prevents 
-    // ... the context object of plugins from passing the -- --livereload flag correctly.
-    // ... directly inspecting the process.argv allows us to circumvent that issue.
-    var emulateWithLiveReload = ParseOptions(process.argv).livereload;
-
-    // Allow livereload to be started by running: `cordova run android --livereload` or by running `cordova run android -- --livereload`
-    var isLiveReload = (context.opts.options.indexOf('--livereload') === -1);
-    isLiveReload = isLiveReload || emulateWithLiveReload;
-    if (!context.opts.livereload && isLiveReload) {
-        return false;
-    }
-
-    // Has the user issued a livereload compatible command ? e.g: run or emulate
-    var regex = /(.*)(run|emulate)(.*)/i;
-
-    var isCordovaRunOrEmulateCmd = regex.test(context.cmdLine);
-
-    return isCordovaRunOrEmulateCmd ? true : false;
+    // There is a bug in cordova-lib upto at least version 5.3.x that prevents the `cordova emulate` command 
+    // ... from passing context object of plugins from passing the -- --livereload flag correctly.
+    // ... using `isLiveReloadActive` allows us to circumvent that issue.
+    var livereloadOptions = ParseOptions();
+    return livereloadOptions.livereload && ((livereloadOptions.run || livereloadOptions.emulate) && !isLiveReloadActive()); // Make sure we're not already in livereload mode
 };
 
 // config.xml can be found in the projectRoot directory or within the projectRoot/www folder
@@ -78,22 +64,14 @@ module.exports.ChangeStartPage = function(projectRoot, plat, platformIndexUrl) {
 };
 
 // Parses LiveReload options off of process.argv
-module.exports.ParseOptions = ParseOptions = function(processArgv) {
+module.exports.ParseOptions = ParseOptions = function() {
 
     var knownOpts = {
         'livereload': Boolean,
         'ignore': String
     };
 
-    processArgv = processArgv || process.args;
-
-    debugger;
-
-    var parsedOptions = nopt(knownOpts, {}, processArgv, 2);
-
-    // All livereload options happen after the -- -- 
-    // What if we want to enable --livereload in the future ? (instead of -- --livereload) : `cordova run android --livereload`
-    // Test all cases !
+    var parsedOptions = nopt(knownOpts, {}, process.args, 2);
     var parsedLivereloadOptions = nopt(knownOpts, {}, parsedOptions.argv.remain, 2);
 
     return {
@@ -102,4 +80,12 @@ module.exports.ParseOptions = ParseOptions = function(processArgv) {
         livereload: parsedOptions.livereload || parsedLivereloadOptions.livereload,
         ignore: parsedOptions.ignore || parsedLivereloadOptions.ignore
     };
+};
+
+module.exports.setLiveReloadToActive = function() {
+    GLOBAL.isLiveReloadActive = true;
+};
+
+module.exports.isLiveReloadActive = isLiveReloadActive = function() {
+    return !!GLOBAL.isLiveReloadActive;
 };

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "properties-parser": "0.2.3",
     "cheerio": "0.19.0",
     "glob": "5.0.15",
-    "lodash.merge": "3.3.2"
+    "lodash.merge": "3.3.2",
+    "nopt": "3.0.4"
   }
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -13,5 +13,6 @@
 
     <hook type="after_plugin_add" src="lib/dependenciesInstall.js" />
     <hook type="after_prepare" src="lib/postPrepareHook.js" />
-    <hook type="after_run" src="lib/postRunHook.js" />
+    <hook type="after_run" src="lib/postEmulateRunHook.js" />
+    <hook type="after_emulate" src="lib/postEmulateRunHook.js" />
 </plugin>

--- a/tests-to-automate.txt
+++ b/tests-to-automate.txt
@@ -106,7 +106,6 @@
 - cordova emulate android => works
 - cordova emulate android -- --livereload => works
 - cordova emulate android -- --livereload --ignore=/lib/** => work
-- cordova emulate android -- --livereload --ignore=  /lib/** => works
 - cordova emulate android -- --livereload --ignore= => works
 - cordova emulate android -- --livereload --ignore => works
 

--- a/tests-to-automate.txt
+++ b/tests-to-automate.txt
@@ -102,3 +102,12 @@
 - Run all the tests on the 3 OSes: Linux, OSX, Windows
 - 
 
+===========Bug Fix for emulate option==========
+- cordova emulate android => works
+- cordova emulate android -- --livereload => works
+- cordova emulate android -- --livereload --ignore=/lib/** => work
+- cordova emulate android -- --livereload --ignore=  /lib/** => works
+- cordova emulate android -- --livereload --ignore= => works
+- cordova emulate android -- --livereload --ignore => works
+
+


### PR DESCRIPTION
Currently, running `cordova emulate android -- --livereload` doesn't start livereload & device syncing mechanism.
This PR's goal is to fix that issue.
