### PR TITLE
Allow local tunnelling to circumvent firewall/proxy issues.

### DIFF
--- a/lib/livereload.js
+++ b/lib/livereload.js
@@ -82,7 +82,8 @@ function startServer() {
             return;
         }
 
-        var server_url = bs.options.getIn(['urls', 'external']);
+        // If the user specified the '--tunnel' option, use a localtunnel.me address
+        var server_url = self.options.tunnel ? bs.options.getIn(['urls', 'tunnel']) : bs.options.getIn(['urls', 'external']);
 
         // In case there is no external url
         // e.g: When the machine is not connected to any network

--- a/lib/postPrepareHook.js
+++ b/lib/postPrepareHook.js
@@ -111,7 +111,8 @@ module.exports = function(context) {
             // Don't run prepare on the initial addition of files,
             // Only do it on subsequent ones
             ignoreInitial: true
-        }
+        },
+        tunnel: livereloadOptions.tunnel || false
     });
 
     return lr.startServer().then(function(server_url) {

--- a/lib/utils/helpers.js
+++ b/lib/utils/helpers.js
@@ -68,7 +68,8 @@ module.exports.parseOptions = parseOptions = function() {
 
     var knownOpts = {
         'livereload': Boolean,
-        'ignore': String
+        'ignore': String,
+        'tunnel': Boolean
     };
 
     var parsedOptions = nopt(knownOpts, {}, process.args, 2);
@@ -78,7 +79,8 @@ module.exports.parseOptions = parseOptions = function() {
         run: parsedOptions.argv.original.indexOf('run') > -1,
         emulate: parsedOptions.argv.original.indexOf('emulate') > -1,
         livereload: parsedOptions.livereload || parsedLivereloadOptions.livereload,
-        ignore: parsedOptions.ignore || parsedLivereloadOptions.ignore
+        ignore: parsedOptions.ignore || parsedLivereloadOptions.ignore,
+        tunnel: parsedOptions.tunnel || parsedLivereloadOptions.tunnel
     };
 };
 


### PR DESCRIPTION
In cases we are connecting from a network with restrictions (firewalls, proxies, etc...), it might be impossible to have the mobile device connect to the computer.
In those cases, we can enable and make the communication easy by tunnelling the app on the computer  through the internet like so:

`cordova run android -- --livereload --tunnel`
