### PR TITLE
Revert "Making --livereload and --devicesync synonyms."

### DIFF
--- a/lib/utils/helpers.js
+++ b/lib/utils/helpers.js
@@ -66,15 +66,8 @@ module.exports.ChangeStartPage = function(projectRoot, plat, platformIndexUrl) {
 // Parses LiveReload options off of process.argv
 module.exports.parseOptions = parseOptions = function() {
 
-    // --livereload and --devicesync can be used interchangeably.
-    // e.g: `cordova run android -- --livereload` is the same as `cordova run android -- --devicesync`
-    // Making them be the same is necessary because of two reasons:
-    //    1- From TACO, we have to be able to run either `taco run ios android --devicesync` or `taco run android --livereload`
-    //    2- Due to a bug in cordova-lib, we have to parse process.args and not the context. What this means is that when parsing process.args, 
-    //         ... we'll see --devicesync and not --livereload. otherwise, we could have just passed the '--livereload' flag through the plugin's context from TACO.
     var knownOpts = {
         'livereload': Boolean,
-        'devicesync': Boolean,
         'ignore': String,
         'tunnel': Boolean,
         'ghostMode': Boolean
@@ -86,7 +79,7 @@ module.exports.parseOptions = parseOptions = function() {
     return {
         run: parsedOptions.argv.original.indexOf('run') > -1,
         emulate: parsedOptions.argv.original.indexOf('emulate') > -1,
-        livereload: parsedOptions.livereload || parsedLivereloadOptions.livereload || parsedOptions.devicesync || parsedLivereloadOptions.devicesync,
+        livereload: parsedOptions.livereload || parsedLivereloadOptions.livereload,
         ignore: parsedOptions.ignore || parsedLivereloadOptions.ignore,
         tunnel: parsedOptions.tunnel || parsedLivereloadOptions.tunnel,
         ghostMode: parsedOptions.ghostMode || parsedLivereloadOptions.ghostMode


### PR DESCRIPTION
We don't need the '--devicesync' flag anymore as this plugin won't be used
from TACO anymore.
I've changed the way LiveReload will be included in TACO (from plugin architecture to package-based architecture):
https://github.com/Microsoft/TACO/pull/174

This reverts commit 9fc9038d8f084f263cdf2aa5142849fd32681cd3.
