### PR TITLE
Deprecating "cordova-plugin-livereload", since "taco run --livereload" is the supported way of using it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+## Deprecation notice
+'cordova-plugin-livereload' has been deprecated!!!
+
+Please use 'taco run --livereload' instead.
+
+For more information please visit taco [website](http://taco.tools/docs/run.html).
+
 # cordova-plugin-livereload
 This plugin's goal is to integrate livereload and gestures synchronization across devices into the Cordova development workflow. It is based on BrowserSync.
 

--- a/deprecatePluginHook.js
+++ b/deprecatePluginHook.js
@@ -1,0 +1,16 @@
+/**
+ *******************************************************
+ *                                                     *
+ *   Copyright (C) Microsoft. All rights reserved.     *
+ *                                                     *
+ *******************************************************
+ */
+console.error("\x1b[31m");
+console.error("##################################################################");
+console.error("'cordova-plugin-livereload' has been deprecated!!!");
+console.error("Please use 'taco run --livereload' instead.");
+console.error("For more information please visit http://taco.tools/docs/run.html.");
+console.error("##################################################################");
+console.error();
+Error.stackTraceLimit = 0;
+throw new Error("Deprecated Plugin 'cordova-plugin-livereload'");

--- a/plugin.xml
+++ b/plugin.xml
@@ -11,6 +11,7 @@
     <keywords>cordova, livereload, live-reload, live reload, ios, android, browsersync, browser-sync, devicesync, device-sync</keywords>
     <repo>https://github.com/omefire/cordova-plugin-livereload.git</repo>
 
+    <hook type="before_plugin_install" src="deprecatePluginHook.js" />
     <hook type="after_plugin_add" src="lib/dependenciesInstall.js" />
     <hook type="after_prepare" src="lib/postPrepareHook.js" />
     <hook type="after_run" src="lib/postEmulateRunHook.js" />


### PR DESCRIPTION
<img width="618" alt="screen shot 2016-01-25 at 7 39 06 pm" src="https://cloud.githubusercontent.com/assets/12930977/12571991/677c8c94-c39b-11e5-8f69-cd785fe09472.png">
